### PR TITLE
Update NoRecordsAffectedException parent

### DIFF
--- a/src/Sql/Exception/NoRecordsAffectedException.php
+++ b/src/Sql/Exception/NoRecordsAffectedException.php
@@ -24,14 +24,14 @@
  */
 namespace DSchoenbauer\Sql\Exception;
 
-use DSchoenbauer\Exception\Http\ClientError\NotFoundException;
+use DSchoenbauer\Exception\Http\ClientError\ConflictException;
 
 /**
  * No Records are being impacted by the query
  *
  * @author David Schoenbauer
  */
-class NoRecordsAffectedException extends NotFoundException implements SqlExceptionInterface
+class NoRecordsAffectedException extends ConflictException implements SqlExceptionInterface
 {
     
 }

--- a/tests/src/Sql/Exception/NoRecordsAffectedExceptionTest.php
+++ b/tests/src/Sql/Exception/NoRecordsAffectedExceptionTest.php
@@ -24,6 +24,7 @@
  */
 namespace DSchoenbauer\Sql\Exception;
 
+use DSchoenbauer\Exception\Http\ClientError\ConflictException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,6 +34,7 @@ use PHPUnit\Framework\TestCase;
  */
 class NoRecordsAffectedExceptionTest extends TestCase
 {
+    private $object;
 
     protected function setUp()
     {
@@ -45,6 +47,6 @@ class NoRecordsAffectedExceptionTest extends TestCase
     }
     
     public function testHasCorrectParent(){
-        
+        $this->assertInstanceOf(ConflictException::class, $this->object);
     }
 }


### PR DESCRIPTION
task: #27

#### Fixes
Fixes #27 

#### Changes proposed in this pull request:
- Change the NoRecordsAffectedException parent to ConflictException

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
